### PR TITLE
Refactor config & error handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,69 +1,15 @@
-import os
-import shutil
 import logging
 from pathlib import Path
-from typing import Any, Dict, Optional
-import yaml
-import modules.shittim.error.ShittimError as error
 
-# Configure logger
+from modules.common.config_base import BaseConfig
+
 logger = logging.getLogger('shittim.config')
 
-class Config:
-    _instance = None
-    _config: Dict[str, Any] = {}
-    
-    def __new__(cls):
-        if cls._instance is None:
-            cls._instance = super(Config, cls).__new__(cls)
-            cls._instance._initialized = False
-        return cls._instance
-    
+class Config(BaseConfig):
     def __init__(self):
-        if self._initialized:
-            return
-            
-        self._initialized = True
-        self.config_dir = Path(__file__).parent
-        self.default_config_path = self.config_dir / "shittim.config.default.yaml"
-        self.config_path = self.config_dir / "shittim.config.yaml"
-        
-        self._ensure_config_exists()
-        self._load_config()
-    
-    def _ensure_config_exists(self) -> bool:
-        if not self.config_path.exists():
-            if not self.default_config_path.exists():
-                logger.error("shittim.config.yaml not found. Please download it from the repository.")
-                raise error.ShittimConfigDefaultNotFoundError("shittim.config.default.yaml not found")
-            
-            shutil.copy(self.default_config_path, self.config_path)
-            logger.info(f"Created config file at {self.config_path}. Please edit it with your settings and restart the bot.")
-            return False
-        return True
-    
-    def _load_config(self) -> None:
-        try:
-            with open(self.config_path, 'r', encoding='utf-8') as f:
-                self._config = yaml.safe_load(f) or {}
-        except Exception as e:
-            logger.error(f"Error loading config file: {e}")
-            self._config = {}
-    
-    def get(self, key: str, default: Any = None) -> Any:
-        keys = key.split('.')
-        value = self._config
-        
-        try:
-            for k in keys:
-                value = value[k]
-            return value
-        except (KeyError, TypeError):
-            return default
-    
-    def get_message(self, key: str, **kwargs) -> str:
-        message = self.get(f"messages.{key}", key)
-        try:
-            return message.format(**kwargs)
-        except (KeyError, AttributeError):
-            return message
+        super().__init__(
+            module_name='shittim',
+            config_dir=Path(__file__).parent,
+            config_file='shittim.config.yaml',
+            default_file='shittim.config.default.yaml'
+        )

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ import warnings
 from discord.ext import commands
 
 from config import Config
-import modules.shittim.error.ShittimError as error
+import modules.common.error as error
 
 logging.basicConfig(level=logging.INFO,
                     format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -19,7 +19,7 @@ class Shittim(commands.Bot):
             for warning in w:
                 logging.warning(f"Warning while loading config:\n{warning.message}" + "ShittimでのWarningは致命的なものなので起動できません。")
                 sys.exit(1)
-        except error.ShittimConfigDefaultNotFoundError as e:
+        except error.ConfigDefaultNotFoundError as e:
             logging.error("Shittimのdefault.configファイルが見つかりませんでした。起動できません。再インストールするか、リポジトリから最新のdefault.configファイルを取得してください。")
             sys.exit(1)
 

--- a/modules/common/config_base.py
+++ b/modules/common/config_base.py
@@ -1,0 +1,67 @@
+import logging
+import shutil
+from pathlib import Path
+from typing import Any, Dict
+import yaml
+
+from modules.common.error import ConfigDefaultNotFoundError, FirstRunWarning
+
+logger = logging.getLogger(__name__)
+
+class BaseConfig:
+    _instances: Dict[type, "BaseConfig"] = {}
+
+    def __new__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            instance = super(BaseConfig, cls).__new__(cls)
+            cls._instances[cls] = instance
+            instance._initialized = False
+        return cls._instances[cls]
+
+    def __init__(self, module_name: str, config_dir: Path, config_file: str, default_file: str):
+        if self._initialized:
+            return
+        self._initialized = True
+
+        self.module_name = module_name
+        self.config_dir = config_dir
+        self.config_path = config_dir / config_file
+        self.default_config_path = config_dir / default_file
+        self._config: Dict[str, Any] = {}
+
+        self._ensure_config_exists()
+        self._load_config()
+
+    def _ensure_config_exists(self) -> None:
+        if not self.config_path.exists():
+            if not self.default_config_path.exists():
+                logger.error(f"{self.config_path.name} not found. Please download it from the repository.")
+                raise ConfigDefaultNotFoundError(self.module_name, f"{self.default_config_path.name} not found")
+            shutil.copy(self.default_config_path, self.config_path)
+            logger.info(f"Created config file at {self.config_path}. Please edit it with your settings and restart the bot.")
+            raise FirstRunWarning(self.module_name, f"{self.config_path.name} not found")
+
+    def _load_config(self) -> None:
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                self._config = yaml.safe_load(f) or {}
+        except Exception as e:
+            logger.error(f"Error loading config file: {e}")
+            self._config = {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        keys = key.split('.')
+        value = self._config
+        try:
+            for k in keys:
+                value = value[k]
+            return value
+        except (KeyError, TypeError):
+            return default
+
+    def get_message(self, key: str, **kwargs) -> str:
+        message = self.get(f"messages.{key}", key)
+        try:
+            return message.format(**kwargs)
+        except (KeyError, AttributeError):
+            return message

--- a/modules/common/error.py
+++ b/modules/common/error.py
@@ -1,0 +1,19 @@
+class ConfigError(Exception):
+    """Base error for config related issues."""
+    def __init__(self, module: str, message: str):
+        super().__init__(f"[{module}] {message}")
+        self.module = module
+
+class ConfigDefaultNotFoundError(ConfigError):
+    """Raised when the default config file is missing."""
+    pass
+
+class ConfigNotFoundError(ConfigError):
+    """Raised when the main config file is missing."""
+    pass
+
+class FirstRunWarning(Warning):
+    """Warning raised on first run when config is created."""
+    def __init__(self, module: str, message: str):
+        super().__init__(f"[{module}] {message}")
+        self.module = module

--- a/modules/llmcord_plana/error/PlanaError.py
+++ b/modules/llmcord_plana/error/PlanaError.py
@@ -1,23 +1,35 @@
-class PlanaError(Exception):
+from modules.common.error import (
+    ConfigError,
+    ConfigDefaultNotFoundError,
+    FirstRunWarning,
+)
+
+
+class PlanaError(ConfigError):
     """PLANA系共通の基底例外"""
-    pass
+    def __init__(self, message: str):
+        super().__init__('llmcord_plana', message)
+
 
 class PlanaConfigNotFoundError(PlanaError):
     HOW_TO_FIX = (
-        "[HOW TO FIX]: 通常は起動時に自動的に設定ファイルが生成されます。"
-        "基底コンフィグファイルが欠如している可能性があります。"
+        "[HOW TO FIX]: 通常は起動時に自動的に設定ファイルが生成されます。",
+        "基底コンフィグファイルが欠如している可能性があります。",
     )
 
     def __init__(self, message: str):
         super().__init__(f"{message}\n {self.HOW_TO_FIX}")
 
-class PlanaDefaultConfigNotFound(PlanaError):
+
+class PlanaDefaultConfigNotFound(ConfigDefaultNotFoundError):
     HOW_TO_FIX = (
-        "[HOW TO FIX]: 基底コンフィグファイルが欠如しています。再インストールするか、リポジトリから取得してください。"
+        "[HOW TO FIX]: 基底コンフィグファイルが欠如しています。再インストールするか、リポジトリから取得してください。",
     )
-    def __init__(self, message: str):
-        super().__init__(f"{message}\n {self.HOW_TO_FIX}")
 
-class PlanaFirstRunWarning(Warning):
     def __init__(self, message: str):
-        super().__init__(message)
+        super().__init__('llmcord_plana', f"{message}\n {self.HOW_TO_FIX}")
+
+
+class PlanaFirstRunWarning(FirstRunWarning):
+    def __init__(self, message: str):
+        super().__init__('llmcord_plana', message)

--- a/modules/llmcord_plana/llmcord_plana.py
+++ b/modules/llmcord_plana/llmcord_plana.py
@@ -22,7 +22,7 @@ import sys
 from openai import AsyncOpenAI, RateLimitError
 
 from modules.llmcord_plana.plugins import load_plugins
-import modules.llmcord_plana.error.PlanaError as error
+import modules.common.error as error
 
 logging.basicConfig(
     level=logging.INFO,
@@ -776,7 +776,8 @@ class LLMcord(commands.Cog):
         if os.path.exists(cfg_path):
             return True
         if not os.path.exists(default_path):
-            raise error.PlanaDefaultConfigNotFound(
+            raise error.ConfigDefaultNotFoundError(
+                "llmcord_plana",
                 f"{default_path} が見つかりません。"
             )
         shutil.copy2(default_path, cfg_path)
@@ -788,5 +789,8 @@ class LLMcord(commands.Cog):
 
 async def setup(bot: commands.Bot):
     if not LLMcord.ensure_config():
-        raise error.PlanaFirstRunWarning("生成されたファイルを編集してから再度起動してください。")
+        raise error.FirstRunWarning(
+            "llmcord_plana",
+            "生成されたファイルを編集してから再度起動してください。"
+        )
     await bot.add_cog(LLMcord(bot))

--- a/modules/music_arona/config.py
+++ b/modules/music_arona/config.py
@@ -1,72 +1,18 @@
-import os
-import shutil
 import logging
 from pathlib import Path
-from typing import Any, Dict, Optional
-import yaml
-from warnings import warn
-import modules.music_arona.error.AronaError as error
 
-# Configure logger
+from modules.common.config_base import BaseConfig
+
 logger = logging.getLogger('arona.config')
 
-class Config:
-    _instance = None
-    _config: Dict[str, Any] = {}
-    
-    def __new__(cls):
-        if cls._instance is None:
-            cls._instance = super(Config, cls).__new__(cls)
-            cls._instance._initialized = False
-        return cls._instance
-    
+class Config(BaseConfig):
     def __init__(self):
-        if self._initialized:
-            return
-            
-        self._initialized = True
-        self.config_dir = Path(__file__).parent.parent.parent
-        self.default_config_path = self.config_dir / "arona.config.default.yaml"
-        self.config_path = self.config_dir / "arona.config.yaml"
-        
-        self._ensure_config_exists()
-        self._load_config()
-    
-    def _ensure_config_exists(self) -> None:
-        if not self.config_path.exists():
-            if not self.default_config_path.exists():
-                logger.error("arona.config.yaml not found. Please download it from the repository.")
-                raise error.AronaDefaultConfigNotFound("arona.config.default.yaml not found")
-                
-            shutil.copy(self.default_config_path, self.config_path)
-            logger.info(f"Created config file at {self.config_path}. Please edit it with your settings and restart the bot.")
-            raise error.AronaFirstRunWarning("arona.config.yaml not found")
-    
-    def _load_config(self) -> None:
-        try:
-            with open(self.config_path, 'r', encoding='utf-8') as f:
-                self._config = yaml.safe_load(f) or {}
-        except Exception as e:
-            logger.error(f"Error loading config file: {e}")
-            self._config = {}
-    
-    def get(self, key: str, default: Any = None) -> Any:
-        keys = key.split('.')
-        value = self._config
-        
-        try:
-            for k in keys:
-                value = value[k]
-            return value
-        except (KeyError, TypeError):
-            return default
-    
-    def get_message(self, key: str, **kwargs) -> str:
-        message = self.get(f"messages.{key}", key)
-        try:
-            return message.format(**kwargs)
-        except (KeyError, AttributeError):
-            return message
+        super().__init__(
+            module_name='music_arona',
+            config_dir=Path(__file__).parent.parent.parent,
+            config_file='arona.config.yaml',
+            default_file='arona.config.default.yaml'
+        )
 
 config = Config()
 get = config.get

--- a/modules/music_arona/error/AronaError.py
+++ b/modules/music_arona/error/AronaError.py
@@ -1,23 +1,35 @@
-class AronaError(Exception):
+from modules.common.error import (
+    ConfigError,
+    ConfigDefaultNotFoundError,
+    FirstRunWarning,
+)
+
+
+class AronaError(ConfigError):
     """ARONA系共通の基底例外"""
-    pass
+    def __init__(self, message: str):
+        super().__init__('music_arona', message)
+
 
 class AronaConfigNotFoundError(AronaError):
     HOW_TO_FIX = (
-        "[HOW TO FIX]: 通常は起動時に自動的に設定ファイルが生成されます。"
-        "基底コンフィグファイルが欠如している可能性があります。"
+        "[HOW TO FIX]: 通常は起動時に自動的に設定ファイルが生成されます。",
+        "基底コンフィグファイルが欠如している可能性があります。",
     )
 
     def __init__(self, message: str):
         super().__init__(f"{message}\n {self.HOW_TO_FIX}")
 
-class AronaDefaultConfigNotFound(AronaError):
+
+class AronaDefaultConfigNotFound(ConfigDefaultNotFoundError):
     HOW_TO_FIX = (
-        "[HOW TO FIX]: 基底コンフィグファイルが欠如しています。再インストールするか、リポジトリから取得してください。"
+        "[HOW TO FIX]: 基底コンフィグファイルが欠如しています。再インストールするか、リポジトリから取得してください。",
     )
-    def __init__(self, message: str):
-        super().__init__(f"{message}\n {self.HOW_TO_FIX}")
 
-class AronaFirstRunWarning(Warning):
     def __init__(self, message: str):
-        super().__init__(message)
+        super().__init__('music_arona', f"{message}\n {self.HOW_TO_FIX}")
+
+
+class AronaFirstRunWarning(FirstRunWarning):
+    def __init__(self, message: str):
+        super().__init__('music_arona', message)

--- a/modules/music_arona/music_arona.py
+++ b/modules/music_arona/music_arona.py
@@ -11,7 +11,7 @@ from discord.ext import commands
 from modules.music_arona.services import ytdlp_wrapper as ytdl
 from modules.music_arona.services.guild_player import GuildPlayer
 from modules.music_arona.config import Config
-import modules.music_arona.error.AronaError as error
+import modules.common.error as error
 
 logger = logging.getLogger("arona.music")
 

--- a/modules/shittim/error/ShittimError.py
+++ b/modules/shittim/error/ShittimError.py
@@ -1,6 +1,9 @@
-class ShittimError(Exception):
-    pass
+from modules.common.error import ConfigError, ConfigDefaultNotFoundError
 
-class ShittimConfigDefaultNotFoundError(ShittimError):
+class ShittimError(ConfigError):
     def __init__(self, message: str):
-        super().__init__(message)
+        super().__init__('shittim', message)
+
+class ShittimConfigDefaultNotFoundError(ConfigDefaultNotFoundError):
+    def __init__(self, message: str):
+        super().__init__('shittim', message)


### PR DESCRIPTION
## Summary
- centralize configuration logic in `modules/common/config_base.py`
- standardize error handling with `modules/common/error.py`
- update Shittim and Arona config modules to inherit from the new base
- adjust modules to use generic errors

## Testing
- `python -m py_compile config.py modules/music_arona/config.py modules/llmcord_plana/llmcord_plana.py modules/common/config_base.py modules/common/error.py modules/shittim/error/ShittimError.py modules/music_arona/error/AronaError.py modules/llmcord_plana/error/PlanaError.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68470410195c8326818d3216beab816a