### PR TITLE
Add auto VC exit & interactive queue

### DIFF
--- a/modules/music_arona/services/guild_player.py
+++ b/modules/music_arona/services/guild_player.py
@@ -59,6 +59,15 @@ class GuildPlayer:
         random.shuffle(tmp)
         self._queue = deque(tmp)
 
+    def paged_upcoming(self, *, page_size: int = 10) -> list[list[Track]]:
+        """Return upcoming tracks split into pages."""
+        pages: list[list[Track]] = [[]]
+        for t in self._queue:
+            if len(pages[-1]) >= page_size:
+                pages.append([])
+            pages[-1].append(t)
+        return pages
+
     def remove(self, position: int) -> Track:
         """0-based index の曲を除去して返す。"""
         if position < 0 or position >= len(self._queue):


### PR DESCRIPTION
## Summary
- auto-stop guild player when everyone leaves the voice channel
- interactive queue view with paginated embeds
- helper for paged queue retrieval

## Testing
- `python -m py_compile modules/music_arona/services/guild_player.py modules/music_arona/music_arona.py`

------
https://chatgpt.com/codex/tasks/task_e_684dd69527748326be343b464cd08d32